### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include uitable/*.md


### PR DESCRIPTION
Include missing files in sdist for #1

Tested with

```
+++ mktemp -d
++ D=/tmp/tmp.MkQvOXVgj8
++ trap 'rm -rf /tmp/tmp.MkQvOXVgj8' EXIT
++ python -m venv /tmp/tmp.MkQvOXVgj8
++ python setup.py sdist -d /tmp/tmp.MkQvOXVgj8
running sdist
running egg_info
writing uitable.egg-info/PKG-INFO
writing dependency_links to uitable.egg-info/dependency_links.txt
writing top-level names to uitable.egg-info/top_level.txt
reading manifest file 'uitable.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'uitable.egg-info/SOURCES.txt'
running check
creating uitable-0.0.1
creating uitable-0.0.1/uitable
creating uitable-0.0.1/uitable.egg-info
creating uitable-0.0.1/uitable/utils
copying files to uitable-0.0.1...
copying MANIFEST.in -> uitable-0.0.1
copying README.md -> uitable-0.0.1
copying setup.py -> uitable-0.0.1
copying uitable/README.md -> uitable-0.0.1/uitable
copying uitable/__init__.py -> uitable-0.0.1/uitable
copying uitable/main.py -> uitable-0.0.1/uitable
copying uitable/test.py -> uitable-0.0.1/uitable
copying uitable.egg-info/PKG-INFO -> uitable-0.0.1/uitable.egg-info
copying uitable.egg-info/SOURCES.txt -> uitable-0.0.1/uitable.egg-info
copying uitable.egg-info/dependency_links.txt -> uitable-0.0.1/uitable.egg-info
copying uitable.egg-info/not-zip-safe -> uitable-0.0.1/uitable.egg-info
copying uitable.egg-info/top_level.txt -> uitable-0.0.1/uitable.egg-info
copying uitable/utils/__init__.py -> uitable-0.0.1/uitable/utils
copying uitable/utils/exceptions.py -> uitable-0.0.1/uitable/utils
Writing uitable-0.0.1/setup.cfg
Creating tar archive
removing 'uitable-0.0.1' (and everything under it)
++ cd /
++ /tmp/tmp.MkQvOXVgj8/bin/pip install /tmp/tmp.MkQvOXVgj8/uitable-0.0.1.tar.gz
Processing /tmp/tmp.MkQvOXVgj8/uitable-0.0.1.tar.gz
Installing collected packages: uitable
  Running setup.py install for uitable: started
    Running setup.py install for uitable: finished with status 'done'
Successfully installed uitable-0.0.1
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
++ echo Success
Success
+++ rm -rf /tmp/tmp.MkQvOXVgj8
```
